### PR TITLE
Alternate versions of fileTape and runDrive

### DIFF
--- a/Data/Rakhana/Tape.hs
+++ b/Data/Rakhana/Tape.hs
@@ -28,9 +28,7 @@ module Data.Rakhana.Tape
     , driveSeek
     , driveTop
     , fileTape
-    , fileTape'
     , runDrive
-    , runDrive'
     ) where
 
 --------------------------------------------------------------------------------
@@ -107,25 +105,9 @@ newTapeState path
     = fmap (initTapeState path) $ openBinaryFile path ReadMode
 
 --------------------------------------------------------------------------------
-fileTape :: MonadIO m => FilePath -> Tape m r
-fileTape path
-    = do s <- liftIO $ newTapeState path
-         r <- respond Unit
-         tapeLoop dispatch s r
-  where
-    dispatch s Top           = tapeTop s
-    dispatch s Bottom        = tapeBottom s
-    dispatch s (Seek i)      = tapeSeek s i
-    dispatch s GetSeek       = tapeGetSeek s
-    dispatch s (Get i)       = tapeGet s i
-    dispatch s (GetLazy i)   = tapeGetLazy s i
-    dispatch s (Direction o) = tapeDirection s o
-    dispatch s (Peek i)      = tapePeek s i
-    dispatch s (Discard i)   = tapeDiscard s i
 
-
-fileTape' :: MonadIO m => FilePath -> TReq -> Tape m r
-fileTape' path r =
+fileTape :: MonadIO m => FilePath -> TReq -> Tape m r
+fileTape path r =
     do s <- liftIO $ newTapeState path
        tapeLoop dispatch s r
   where
@@ -344,8 +326,5 @@ driveDiscard :: Monad m => Int -> Drive m ()
 driveDiscard i = void $ request $ Discard i
 
 --------------------------------------------------------------------------------
-runDrive :: Monad m  => (forall r. Tape m r) -> Drive m a  -> m a
-runDrive tape drive = runEffect (tape >>~ const drive)
-
-runDrive' server drive = runEffect $ server +>> drive
+runDrive server drive = runEffect $ server +>> drive
 


### PR DESCRIPTION
This is an example of an alternate way to write the `fileTape` and `runDrive` functions which avoids the dummy `respond Unit` call in `fileTape`. You also might be able to remove the need for `Unit` in the `TResp` type.

Example usage:

```
example = runDrive' (fileTape' "some-path") driver
```

See also this thread in the pipes mailing list:

https://groups.google.com/d/msg/haskell-pipes/qK5c61mALKI/9miuMIijAQAJ
